### PR TITLE
XRootDFile init stuff

### DIFF
--- a/tests/data/multiline.txt
+++ b/tests/data/multiline.txt
@@ -1,0 +1,7 @@
+Oh dear Ocelot,
+What kind of animal are you anyway?
+A cat?
+Probably.
+Something cat-like.
+You do not have opposable thumbs.
+Just like most cats.

--- a/tests/fixture.py
+++ b/tests/fixture.py
@@ -17,7 +17,7 @@ import pytest
 
 def mkurl(p):
     """Generate test root URL."""
-    return "root://localhost{0}".format(p)
+    return "root://localhost/{0}".format(p)
 
 
 @pytest.fixture

--- a/tests/test_opener.py
+++ b/tests/test_opener.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from fixture import mkurl, tmppath
 from fs.opener import opener
-from xrootdfs import XRootDOpener
+from xrootdfs import XRootDFile, XRootDFS, XRootDOpener
 
 
 def test_parse(tmppath):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,45 +6,55 @@
 # xrootdfs is free software; you can redistribute it and/or modify it under the
 # terms of the Revised BSD License; see LICENSE file for more details.
 
-"""Test of XRootDFS."""
+"""Test of XRootDFS utils."""
 
 from __future__ import absolute_import, print_function, unicode_literals
 
 import pytest
-
-from fs.errors import FSError
-
-from xrootdfs.utils import spliturl
+from XRootD.client.flags import OpenFlags
+from xrootdfs.utils import is_valid_path, spliturl, \
+    translate_file_mode_to_flags
 
 
 def test_spliturl():
     """Test spliturl."""
-    root, path = spliturl("root://eosuser.cern.ch/eos/user/")
-    assert root == "root://eosuser.cern.ch/"
-    assert path == "/eos/user/"
+    root, path, args = spliturl("root://eosuser.cern.ch//eos/user/")
+    assert root == "root://eosuser.cern.ch"
+    assert path == "//eos/user/"
 
-    root, path = spliturl("root://eosuser.cern.ch/")
-    assert root == "root://eosuser.cern.ch/"
-    assert path == ""
-
-    root, path = spliturl("root://eosuser.cern.ch//")
-    assert root == "root://eosuser.cern.ch/"
+    root, path, args = spliturl("root://eosuser.cern.ch//")
+    assert root == "root://eosuser.cern.ch"
     assert path == "//"
 
-    root, path = spliturl("root://eosuser.cern.ch")
-    assert root == "root://eosuser.cern.ch/"
-    assert path == ""
+    root, path, arg = spliturl("root://eosuser.cern.ch//eos?xrd.wantprot=krb5")
+    assert root == "root://eosuser.cern.ch"
+    assert path == "//eos"
+    assert arg == "xrd.wantprot=krb5"
 
-    root, path = spliturl("root://user:pw@eosuser.cern.ch")
-    assert root == "root://user:pw@eosuser.cern.ch/"
-    assert path == ""
+    root, path, arg = spliturl("root://localhost//")
+    assert root == "root://localhost"
+    assert path == "//"
+    assert arg == ""
 
-    root, path = spliturl("root://eosuser.cern.ch/?xrd.wantprot=krb5")
-    assert root == "root://eosuser.cern.ch/?xrd.wantprot=krb5"
-    assert path == ""
 
-    root, path = spliturl("root://eosuser.cern.ch/eos?xrd.wantprot=krb5")
-    assert root == "root://eosuser.cern.ch/?xrd.wantprot=krb5"
-    assert path == "/eos"
+def test_is_valid_path():
+    assert is_valid_path("//")
+    assert is_valid_path("//something/wicked/this/tub/comes/")
+    assert is_valid_path("//every/time")
+    assert not is_valid_path("")
+    assert not is_valid_path("/")
+    assert not is_valid_path("///")
+    assert not is_valid_path("//missing//what")
 
-    pytest.raises(FSError, spliturl, "http://localhost")
+
+def test_translate_file_mode_to_flags():
+    assert translate_file_mode_to_flags('r') == OpenFlags.READ
+    assert translate_file_mode_to_flags('r-') == OpenFlags.READ
+    assert bool(translate_file_mode_to_flags('r+') & OpenFlags.UPDATE)
+
+    assert translate_file_mode_to_flags('a') == OpenFlags.UPDATE
+    assert translate_file_mode_to_flags('a+') == OpenFlags.UPDATE
+
+    assert translate_file_mode_to_flags('w') == OpenFlags.DELETE
+    assert translate_file_mode_to_flags('w-') == OpenFlags.DELETE
+    assert translate_file_mode_to_flags('w+') == OpenFlags.DELETE

--- a/tests/test_xrdfile.py
+++ b/tests/test_xrdfile.py
@@ -1,0 +1,403 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of xrootdfs
+# Copyright (C) 2015 CERN.
+#
+# xrootdfs is free software; you can redistribute it and/or modify it under the
+# terms of the Revised BSD License; see LICENSE file for more details.
+
+"""Test of XRootDFS."""
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from os.path import join
+
+import pytest
+from fixture import mkurl, tmppath
+from fs.errors import InvalidPathError, PathError, ResourceNotFoundError
+from xrootdfs import XRootDFile
+from xrootdfs.utils import is_valid_path, is_valid_url
+
+
+def test_init_basic(tmppath):
+    """Test basic initialization of existing file."""
+
+    fname = 'testa.txt'
+    fpath = 'data/'
+    fcontents = 'testa.txt\n'
+    full_fpath = join(tmppath, fpath, fname)
+    xfile = XRootDFile(mkurl(full_fpath))
+    assert xfile
+    assert type(xfile == XRootDFile)
+    assert xfile._file
+    assert xfile.mode == 'r'
+
+    # Verify that underlying/wrapped file can be read.
+    statmsg, res = xfile._file.read()
+    assert res == fcontents
+
+
+def test_init_writemode_basic(tmppath):
+    # Non-existing file is created.
+    fn, fp, fc = 'nope', 'data/', ''
+    full_path = join(tmppath, fp, fn)
+    xfile = XRootDFile(mkurl(full_path), mode='w+')
+    assert xfile
+    assert xfile.read() == fc
+
+    # Existing file is truncated
+    fd = get_tsta_file(tmppath)
+    full_path = fd['full_path']
+    xfile = XRootDFile(mkurl(full_path), mode='w+')
+    assert xfile
+    assert xfile.read() == ''
+    assert xfile._get_size() == 0
+    assert xfile.tell() == 0
+
+
+def test_init_readmode_basic(tmppath):
+    # Non-existing file causes what?
+    # Resource not found error.
+    fn, fp, fc = 'nope', 'data/', ''
+    full_path = join(tmppath, fp, fn)
+    pytest.raises(ResourceNotFoundError, XRootDFile, mkurl(full_path),
+                  mode='r')
+
+    # Existing file can be read?
+    fd = get_tsta_file(tmppath)
+    full_path, fc = fd['full_path'], fd['contents']
+    xfile = XRootDFile(mkurl(full_path), mode='r')
+    assert xfile
+    assert xfile.read() == fc
+
+
+def get_tsta_file(tmppath):
+    fn, fd = 'testa.txt', 'data'
+    return get_file(fn, fd, tmppath)
+
+
+def get_mltl_file(tmppath):
+    fn, fp = 'multiline.txt', 'data'
+    return get_file(fn, fp, tmppath)
+
+
+def get_file(fn, fp, tmppath):
+    fpp = join(tmppath, fp, fn)
+    with open(fpp) as f:
+        fc = f.read()
+    return {'filename': fn, 'dir': fp, 'contents': fc, 'full_path': fpp}
+
+
+def test_open_close(tmppath):
+    """Test close() on an open file."""
+    fd = get_tsta_file(tmppath)
+    full_path = fd['full_path']
+    xfile = XRootDFile(mkurl(full_path))
+    assert xfile
+    xfile.close()
+    assert xfile.closed
+    assert not xfile._file.is_open()
+
+
+def test_read_existing(tmppath):
+    """Test read() on an existing non-empty file."""
+    fd = get_tsta_file(tmppath)
+    full_path, fc = fd['full_path'], fd['contents']
+    xfile = XRootDFile(mkurl(full_path))
+
+    res = xfile.read()
+    assert res == fc
+    # After having read the entire file, the file pointer is at the
+    # end of the file and consecutive reads return the empty string.
+    assert xfile.read() == ''
+
+    # reset ipp to start
+    xfile.seek(0)
+    assert xfile.read(1) == fc[0]
+    assert xfile.read(2) == fc[1:3]
+    overflow_read = xfile.read(len(fc))
+    assert overflow_read == fc[3:]
+
+
+def test__is_open(tmppath):
+    """Test _is_open()"""
+    fd = get_tsta_file(tmppath)
+    full_path = fd['full_path']
+    xfile = XRootDFile(mkurl(full_path))
+    assert xfile._is_open()
+    xfile.close()
+    assert not xfile._is_open()
+
+
+def test__get_size(tmppath):
+    """Tests for __get_size()."""
+    fd = get_tsta_file(tmppath)
+    full_path, fc = fd['full_path'], fd['contents']
+    xfile = XRootDFile(mkurl(full_path))
+
+    assert xfile._get_size() == len(fc)
+
+    # Length of empty file
+    xfile = XRootDFile(mkurl(join(tmppath, fd['dir'], 'whut')), 'w+')
+    assert xfile._get_size() == len('')
+
+    # Length of multiline file
+    fd = get_mltl_file(tmppath)
+    fpp, fc = fd['full_path'], fd['contents']
+    xfile = XRootDFile(mkurl(fpp))
+    assert xfile._get_size() == len(fc)
+
+
+def test_seek_and_tell(tmppath):
+    """Basic tests for seek() and tell()."""
+    fd = get_tsta_file(tmppath)
+    full_path, fc = fd['full_path'], fd['contents']
+    xfile = XRootDFile(mkurl(full_path))
+    assert xfile.tell() == 0
+
+    # Read file, then check the internal position pointer.
+    conts = xfile.read()
+    assert xfile.tell() == len(fc)
+    assert conts == fc
+
+    # Seek to beginning, then verify ipp.
+    xfile.seek(0)
+    assert xfile.tell() == 0
+    assert xfile.read() == fc
+
+    newpos = len(fc)//2
+    xfile.seek(newpos)
+    conts2 = xfile.read()
+    assert conts2 == conts[newpos:]
+    assert xfile.tell() == len(fc)
+
+    # Now with a multiline file!
+    fd = get_mltl_file(tmppath)
+    full_path, fc = fd['full_path'], fd['contents']
+    xfile = XRootDFile(mkurl(full_path))
+
+    assert xfile.tell() == 0
+    newpos = len(fc)//3
+    xfile.seek(newpos)
+    assert xfile.tell() == newpos
+    nconts = xfile.read()
+    assert xfile.tell() == len(fc)
+    assert nconts == fc[newpos:]
+
+
+def test_truncate1(tmppath):
+    """Test truncate(0)."""
+    fd = get_tsta_file(tmppath)
+    full_path, fc = fd['full_path'], fd['contents']
+    xfile = XRootDFile(mkurl(full_path), 'r+')
+    # r+ opens for r/w, and won't truncate the file automatically.
+    assert xfile.read() == fc
+    xfile.seek(0)  # Reset ipp.
+
+    # Truncate it to size 0.
+    xfile.truncate(0)
+    assert xfile._get_size() == 0
+    assert xfile.read() == ''
+    assert xfile.tell() == 0
+    xfile.close()
+
+    # Re-open same file.
+    xfile = XRootDFile(mkurl(full_path), 'r+')
+    assert xfile._get_size() == 0
+    assert xfile.read() == ''
+
+    # Truncate it again!
+    xfile.truncate(0)
+    assert xfile._get_size() == 0
+    assert xfile.read() == ''
+
+    # Truncate it twice.
+    xfile.truncate(0)
+    assert xfile._get_size() == 0
+    assert xfile.read() == ''
+
+    # Truncate to 1. Not really sure what the expected behaviour is here.
+    xfile.truncate(1)
+    assert xfile._get_size() == 1
+    assert xfile.read() == ''
+    xfile.close()
+
+    xfile = XRootDFile(mkurl(full_path), 'r+')
+    assert xfile._get_size() == 1
+    assert xfile.read() == '\x00'
+
+
+def test_truncate2(tmppath):
+    """Test truncate(self._size)."""
+    fd = get_tsta_file(tmppath)
+    full_path, fc = fd['full_path'], fd['contents']
+    xfile = XRootDFile(mkurl(full_path), 'r+')
+    conts = xfile.read()
+    assert conts == fc
+
+    xfile.truncate(xfile._get_size())
+    assert xfile.tell() == len(fc)
+    assert xfile._get_size() == len(fc)
+    xfile.seek(0)
+    assert xfile.read() == conts
+
+
+def test_truncate3(tmppath):
+    """Test truncate(0 < size < self._size)."""
+    fd = get_mltl_file(tmppath)
+    full_path, fc = fd['full_path'], fd['contents']
+    xfile = XRootDFile(mkurl(full_path), 'r+')
+
+    newsiz = len(fc)//2
+    xfile.truncate(newsiz)
+    assert xfile.tell() == newsiz
+    xfile.seek(0)
+    assert xfile.read() == fc[:-newsiz]
+
+
+def test_write(tmppath):
+    """Test write()."""
+    # With a new file.
+    xfile = XRootDFile(mkurl(join(tmppath, 'data/nuts')), 'w+')
+    assert xfile._get_size() == 0
+    conts = xfile.read()
+    assert not conts
+
+    nconts = 'Write.'
+    xfile.write(nconts)
+    assert xfile.tell() == len(nconts)
+    assert xfile._is_open()
+    xfile.seek(0)
+    assert xfile._get_size() == len(nconts)
+    assert xfile.read() == nconts
+    xfile.close()
+
+    # Verify persistence after closing.
+    xfile = XRootDFile(mkurl(join(tmppath, 'data/nuts')), 'r+')
+    assert xfile._get_size() == len(nconts)
+    assert xfile.read() == nconts
+
+    # Seek(x>0) followed by a write
+    nc2 = 'hello'
+    cntr = len(nconts)//2
+    xfile.seek(cntr)
+    xfile.write(nc2)
+    assert xfile.tell() == len(nc2) + cntr
+    xfile.seek(0)
+    assert xfile.read() == nconts[:cntr] + nc2
+    xfile.close()
+
+    # Seek(x>0) followed by a write of len < size-x
+    fd = get_tsta_file(tmppath)
+    fp, fc = fd['full_path'], fd['contents']
+    xfile = XRootDFile(mkurl(fp), 'r+')
+    assert xfile.read() == fc
+    xfile.seek(2)
+    nc = 'yo'
+    xfile.write(nc)
+    assert xfile.tell() == len(nc) + 2
+    assert xfile.read() == fc[2+len(nc):]
+
+
+def test_init_paths(tmppath):
+    """Tests how __init__ responds to correct and invalid paths."""
+    # Invalid url should raise error
+    url = "fee-fyyy-/fooo"
+    assert not is_valid_url(url) \
+        and pytest.raises(PathError, XRootDFile, url)
+
+    path = '//ARGMEGXXX//\\///'
+    assert not is_valid_path(path) \
+        and pytest.raises(InvalidPathError, XRootDFile, mkurl(path))
+
+
+def test_init_append(tmppath):
+    """Test for files opened 'a'"""
+    fd = get_tsta_file(tmppath)
+    fp, fc = fd['full_path'], fd['contents']
+    xfile = XRootDFile(mkurl(fp), 'a')
+    assert xfile.mode == 'a'
+    pytest.raises(IOError, xfile.read)
+    assert xfile.tell() == len(fc)
+
+    # Seeking is allowed, but writes still go on the end.
+    xfile.seek(0)
+    assert xfile.tell() == 0
+    newcont = u'butterflies'
+    xfile.write(newcont)
+    assert xfile.tell() == len(fc) + len(newcont)
+    # Can't read in this mode.
+    xfile.close()
+    xfile = XRootDFile(mkurl(fp), 'r')
+    assert xfile.read() == fc + newcont
+
+    xfile.close()
+    xfile = XRootDFile(mkurl(fp), 'a')
+    xfile.write(fc)
+    xfile.seek(0)
+    xfile.read() == fc + newcont + fc
+
+
+def test_init_append(tmppath):
+    """Test for files opened in mode 'a+'."""
+    fd = get_tsta_file(tmppath)
+    fp, fc = fd['full_path'], fd['contents']
+    xfile = XRootDFile(mkurl(fp), 'a+')
+    assert xfile.mode == 'a+'
+    assert xfile.read() == fc
+    assert xfile.tell() == len(fc)
+
+    # Seeking is allowed, but writes still go on the end.
+    xfile.seek(0)
+    assert xfile.tell() == 0
+    newcont = u'butterflies'
+    xfile.write(newcont)
+    assert xfile.tell() == len(fc) + len(newcont)
+    xfile.seek(0)
+    assert xfile.read() == fc + newcont
+    xfile.write(fc)
+    xfile.seek(0)
+    xfile.read() == fc + newcont + fc
+
+
+def test_init_writemode(tmppath):
+    """Tests for opening files in 'w(+)'"""
+    fd = get_tsta_file(tmppath)
+    fp, fc = fd['full_path'], fd['contents']
+    xfile = XRootDFile(mkurl(fp), 'w')
+    pytest.raises(IOError, xfile.read)
+
+    xfile.seek(1)
+    conts = 'what'
+    xfile.write(conts)
+    assert xfile.tell() == 1 + len(conts)
+    assert xfile._size == 1 + len(conts)
+    xfile.close()
+    xfile = XRootDFile(mkurl(fp), 'r')
+    fc = xfile.read()
+    assert fc == '\x00'+conts
+    assert not fc == conts
+
+
+def test_init_streammodes(tmppath):
+    fd = get_tsta_file(tmppath)
+    fp, fc = fd['full_path'], fd['contents']
+    xfile = XRootDFile(mkurl(fp), 'r-')
+    pytest.raises(IOError, xfile.seek, 3)
+    assert xfile._get_size() == len(fc)
+    assert xfile.tell() == 0
+    assert xfile.read() == fc
+    assert xfile.tell() == len(fc)
+
+    xfile.close()
+    xfile = XRootDFile(mkurl(fp), 'w-')
+    pytest.raises(IOError, xfile.read)
+    pytest.raises(IOError, xfile.seek, 3)
+    assert xfile.tell() == 0
+    assert xfile._get_size() == 0
+    conts = 'hugs are delightful'
+    xfile.write(conts)
+    assert xfile.tell() == len(conts)
+    xfile.close()
+    xfile = XRootDFile(mkurl(fp), 'r')
+    assert xfile.read() == conts

--- a/tests/test_xrdflags.py
+++ b/tests/test_xrdflags.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of xrootdfs
+# Copyright (C) 2015 CERN.
+#
+# xrootdfs is free software; you can redistribute it and/or modify it under the
+# terms of the Revised BSD License; see LICENSE file for more details.
+
+"""Test of XRootD File Flags."""
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from os.path import join
+
+import pytest
+from fixture import mkurl, tmppath
+from XRootD import client as xclient
+from XRootD.client.flags import OpenFlags
+
+
+# If "test" is in its name then pytest picks it up.
+def tstfile_a(p):
+    fname = 'data/testa.txt'
+    with open(join(p, fname)) as f:
+        fconts = f.read()
+
+    return fname, fconts
+
+
+def test_READ(tmppath):
+    fname, fconts = tstfile_a(tmppath)
+    ffpath = join(tmppath, fname)
+    xf = xclient.File()
+    xf.open(mkurl(ffpath), OpenFlags.READ)
+    assert xf
+
+    # Can we read?
+    statmsg, content = xf.read()
+    assert content == fconts
+    assert statmsg.ok
+
+    # Can we write?
+    statmsg, res = xf.write('chhhh-eck it')
+    print((statmsg, ))  # Print returned status in case the test fails.
+    assert xf.read()[1] == content
+    assert not statmsg.ok
+    assert statmsg.error
+
+    # Can we truncate?
+    statmsg, res = xf.truncate(0)
+    print((statmsg, ))
+    assert not statmsg.ok
+    assert statmsg.error
+
+
+def test_APPEND(tmppath):
+    fname, fconts = tstfile_a(tmppath)
+    ffpath = join(tmppath, fname)
+    xf = xclient.File()
+    xf.open(mkurl(ffpath), OpenFlags.APPEND)
+    assert xf
+
+    # Can we read?
+    statmsg, content = xf.read()
+    assert content == fconts
+    assert statmsg.ok
+
+    # Can we write?
+    statmsg, res = xf.write('chhhh-eck it')
+    assert xf.read()[1] == content
+    print((statmsg, ))
+    assert not statmsg.ok
+    assert statmsg.error
+
+
+def test_UPDATE(tmppath):
+    fname, fconts = tstfile_a(tmppath)
+    ffpath = join(tmppath, fname)
+    xf = xclient.File()
+    xf.open(mkurl(ffpath), OpenFlags.UPDATE)
+    assert xf
+
+    # Can we read?
+    statmsg, content = xf.read()
+    assert content == fconts
+    assert statmsg.ok
+
+    # Can we write?
+    statmsg, res = xf.write('chhhh-eck it')
+    # assert xf.read()[1] == content
+    # doesn't truncate file
+    print((statmsg, res))
+    assert statmsg.ok
+    assert not statmsg.error
+
+    # Can we truncate?
+    statmsg, res = xf.truncate(0)
+    print((statmsg, res))
+    assert statmsg.ok
+    assert not statmsg.error
+    assert xf.read()[1] == ""
+
+    # what if the file doesn't exist?
+    ffpath = join(tmppath, "newfile")
+    xf = xclient.File()
+    statmsg, res = xf.open(mkurl(ffpath), OpenFlags.UPDATE)
+    print((statmsg, res))
+    assert not statmsg.ok
+    assert statmsg.error
+
+    xf = xclient.File()
+    ffpath = join(tmppath, "newfile")
+    statmsg, res = xf.open(mkurl(ffpath), OpenFlags.NEW)
+    print((statmsg, res))
+    assert statmsg.ok
+    assert not statmsg.error
+
+
+def test_DELETE(tmppath):
+    fname, fconts = tstfile_a(tmppath)
+    ffpath = join(tmppath, fname)
+    xf = xclient.File()
+    xf.open(mkurl(ffpath), OpenFlags.DELETE)
+    assert xf
+    statmsg, res = xf.read()
+    print((statmsg, res))
+    assert statmsg.ok
+    assert not statmsg.error
+    assert res == ""
+
+    # Can we write now?
+    newc = "whaat"
+    statmsg, res = xf.write(newc)
+    print((statmsg, res))
+    assert statmsg.ok
+    assert not statmsg.error
+    assert xf.read()[1] == newc
+    print(xf.read())

--- a/xrootdfs/__init__.py
+++ b/xrootdfs/__init__.py
@@ -69,6 +69,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from .fs import XRootDFS
 from .opener import XRootDOpener
+from .xrdfile import XRootDFile
 from .version import __version__
 
-__all__ = ('__version__', 'XRootDFS', 'XRootDOpener')
+__all__ = ('__version__', 'XRootDFS', 'XRootDOpener', 'XRootDFile')

--- a/xrootdfs/fs.py
+++ b/xrootdfs/fs.py
@@ -14,14 +14,15 @@ import re
 from glob import fnmatch
 
 from fs.base import FS
-from fs.errors import DestinationExistsError, FSError, InvalidPathError, \
-    ResourceInvalidError, UnsupportedError, DirectoryNotEmptyError
+from fs.errors import DestinationExistsError, DirectoryNotEmptyError, \
+    FSError, InvalidPathError, ResourceInvalidError, UnsupportedError
 from fs.path import normpath, pathcombine, pathjoin
 from XRootD.client import FileSystem
 from XRootD.client.flags import AccessMode, DirListFlags, MkDirFlags, \
-    StatInfoFlags
+    OpenFlags, StatInfoFlags
 
-from .utils import is_valid_url, spliturl
+from .utils import is_valid_path, is_valid_url, spliturl
+from .xrdfile import XRootDFile
 
 
 class XRootDFS(FS):
@@ -42,21 +43,28 @@ class XRootDFS(FS):
         'atomic.setcontents': True
     }
 
-    def __init__(self, url, timeout=0, thread_synchronize=True):
+    def __init__(self, url, query=None, timeout=0, thread_synchronize=True):
         """."""
         if not is_valid_url(url):
             raise InvalidPathError(path=url)
 
-        root_url, base_path = spliturl(url)
+        root_url, base_path, queryargs = spliturl(url)
+
+        if not is_valid_path(base_path):
+            raise InvalidPathError(path=base_path)
 
         self.timeout = timeout
+        self.root_url = root_url
         self.base_path = base_path
+        self.query = queryargs or query
         self.client = FileSystem(root_url)
         super(XRootDFS, self).__init__(thread_synchronize=thread_synchronize)
 
     def _p(self, path):
         """Join path to base path."""
-        return pathjoin(self.base_path, path)
+        # fs.path.pathjoin() omits the first '/' in self.base_path.
+        # It is resolved by adding on an additional '/' to its return value.
+        return '/' + pathjoin(self.base_path, path)
 
     def open(self, path, mode='r', buffering=-1, encoding=None, errors=None,
              newline=None, line_buffering=False, **kwargs):
@@ -80,12 +88,9 @@ class XRootDFS(FS):
         :raises `fs.errors.ResourceNotFoundError`: if the path is not found
         """
         # path must be full-on address with the server and everything, yo.
-        # flags = 0
-        # if 'r' in mode:
-        #     flags += OpenFlags.READ
-
-        # return XRootDFile(self._url + path, flags, mode=0)
-        return 1
+        fpath = self.root_url + self._p(path)
+        return XRootDFile(fpath, mode, buffering, encoding, errors, newline,
+                          line_buffering, **kwargs)
 
     def listdir(self,
                 path="./",

--- a/xrootdfs/opener.py
+++ b/xrootdfs/opener.py
@@ -10,13 +10,11 @@
 
 from __future__ import absolute_import, print_function, unicode_literals
 
-from urlparse import urlparse
-
-from fs.opener import Opener, OpenerError, opener
+from fs.opener import Opener, opener
 from fs.path import pathsplit
 
 from .fs import XRootDFS
-from .utils import is_valid_url
+from .utils import spliturl
 
 
 class XRootDOpener(Opener):
@@ -42,17 +40,11 @@ class XRootDOpener(Opener):
         """
         fs_url = "{0}://{1}".format(fs_name, fs_path)
 
-        if not is_valid_url(fs_url):
-            raise OpenerError('Invalid XRootD URL.')
+        root_url, path, query = spliturl(fs_url)
 
-        scheme, netloc, path, params, query, fragment = urlparse(fs_url)
-
-        root_url = "{scheme}://{netloc}?{query}".format(
-            scheme=scheme, netloc=netloc, query=query
-        )
         dirpath, resourcepath = pathsplit(path)
 
-        fs = XRootDFS(root_url)
+        fs = XRootDFS(root_url + dirpath + query)
 
         if create_dir and path:
             fs.makedir(path, recursive=True, allow_recreate=True)
@@ -64,5 +56,6 @@ class XRootDOpener(Opener):
             return fs, None
         else:
             return fs, resourcepath
+
 
 opener.add(XRootDOpener)

--- a/xrootdfs/xrdfile.py
+++ b/xrootdfs/xrdfile.py
@@ -8,41 +8,227 @@
 
 """."""
 
+from __future__ import absolute_import, print_function, unicode_literals
+
+import fs
 import fs.filelike
+from fs import SEEK_CUR, SEEK_END, SEEK_SET
+from fs.errors import InvalidPathError, PathError, ResourceNotFoundError
 from XRootD.client import File as XFile
+
+from .utils import is_valid_path, is_valid_url, spliturl, \
+    translate_file_mode_to_flags
 
 
 class XRootDFile(fs.filelike.FileLikeBase):
+    """Wrapper-like class for XRootD file objects.
 
-    """."""
+    This class understands and will accept the following mode strings,
+    with any additional characters being ignored:
 
-    def __init__(self, path, bufsize=1024 * 64, mode='r'):
-        """."""
-        super(XRootDFile, self).__init__(bufsize)
-        # set .__file to empty xrootd.client.File-object.
-        self.__file = XFile()
+        * r    - open the file for reading only.
+        * r+   - open the file for reading and writing.
+        * r-   - open the file for streamed reading; do not allow seek/tell.
+        * w    - open the file for writing only; create the file if
+                 it doesn't exist; truncate it to zero length.
+        * w+   - open the file for reading and writing; create the file
+                 if it doesn't exist; truncate it to zero length.
+        * w-   - open the file for streamed writing; do not allow seek/tell.
+        * a    - open the file for writing only; create the file if it
+                 doesn't exist; place pointer at end of file.
+        * a+   - open the file for reading and writing; create the file
+                 if it doesn't exist; place pointer at end of file.
 
-        status, response = self.__file.open(path, mode=mode)
-        # todo: raise appropriate errors
+    These are mostly standard except for the "-" indicator, which has
+    been added for efficiency purposes in cases where seeking can be
+    expensive to simulate (e.g. compressed files).  Note that any file
+    opened for both reading and writing must also support seeking.
+    """
 
-    def seek(self, offset, whence=0):
-        """."""
-        self._ifp = offset
+    def __init__(self, path, mode='r', buffering=-1, encoding=None,
+                 errors=None, newline=None, line_buffering=False, **kwargs):
+        """XRootDFile constructor.
 
-    def read(self, size=0, offset=None, timeout=0, callback=None):
-        """."""
-        if offset is None:
-            offset = self._ifp
-        return self._file.read(offset, size, timeout, callback)
+        Raises PathError if the given path isn't a valid XRootD URL,
+        and InvalidPathError if it isn't a valid XRootD file path.
+        """
+        if not is_valid_url(path):
+            raise PathError(path)
 
-    def tell():
-        """."""
-        pass
+        xpath = spliturl(path)[1]
 
-    def truncate(size=None):
-        """."""
-        pass
+        if not is_valid_path(xpath):
+            raise InvalidPathError(xpath)
 
-    def write(string):
-        """."""
-        pass
+        super(XRootDFile, self).__init__()
+
+        # PyFS attributes
+        self.mode = mode
+
+        # XRootD attributes & internals
+        self._file = XFile()
+        self._ipp = 0
+        self._timeout = 0
+        self._callback = None
+        self._fullpath = path
+
+        self._size = 0
+
+        # flag translation
+        self._flags = translate_file_mode_to_flags(mode)
+
+        status, response = self._file.open(self._fullpath, self._flags)
+        if not status.ok:
+            if status.errno == 3011:
+                raise ResourceNotFoundError(self._fullpath)
+            else:
+                raise IOError("Error returned by XRootD server while trying to \
+                               instantiate file.", {'message': status.message,
+                                                    'file': self._fullpath})
+        else:
+            self._size = self._file.stat()[1].size
+
+        # Deal with the modes
+        if self.mode == 'a':
+            self._seek(self._size, SEEK_SET)
+
+    def _read(self, sizehint=-1):
+        """Read approximately <sizehint> bytes from the file-like object.
+
+        This method is to be implemented by subclasses that wish to be
+        readable.  It should read approximately <sizehint> bytes from the
+        file and return them as a string.  If <sizehint> is missing or
+        less than or equal to zero, try to read all the remaining contents.
+
+        The method need not guarantee any particular number of bytes -
+        it may return more bytes than requested, or fewer.  If needed the
+        size hint may be completely ignored.  It may even return an empty
+        string if no data is yet available.
+
+        Because of this, the method must return None to signify that EOF
+        has been reached.  The higher-level methods will never indicate EOF
+        until None has been read from _read().  Once EOF is reached, it
+        should be safe to call _read() again, immediately returning None.
+        """
+        if self._tell() == self._size:
+            return None
+
+        statmsg, res = self._file.read(self._ipp)
+        self._seek(len(res), SEEK_CUR)
+        return res
+
+    def _write(self, string, flushing=False):
+        """Write the given string to the file-like object.
+
+        This method must be implemented by subclasses wishing to be writable.
+        It must attempt to write as much of the given data as possible to the
+        file, but need not guarantee that it is all written.  It may return
+        None to indicate that all data was written, or return as a string any
+        data that could not be written.
+
+        If the keyword argument 'flushing' is true, it indicates that the
+        internal write buffers are being flushed, and *all* the given data
+        is expected to be written to the file. If unwritten data is returned
+        when 'flushing' is true, an IOError will be raised.
+        """
+        if 'a' in self.mode:
+            self._seek(0, SEEK_END)
+
+        statmsg, res = self._file.write(string, self._ipp)
+        if statmsg.ok and not statmsg.error:
+            self._seek(len(string), SEEK_CUR)
+            self._size = max(self._size, self._tell())
+            return None
+        else:
+            raise IOError(("Error writing to file: {0}".format(
+                           statmsg.message), self))
+
+    def _seek(self, offset, whence):
+        """Set the file's internal position pointer, approximately.
+
+        This method should set the file's position to approximately 'offset'
+        bytes relative to the position specified by 'whence'.  If it is
+        not possible to position the pointer exactly at the given offset,
+        it should be positioned at a convenient *smaller* offset and the
+        file data between the real and apparent position should be returned.
+
+        At minimum, this method must implement the ability to seek to
+        the start of the file, i.e. offset=0 and whence=0.  If more
+        complex seeks are difficult to implement then it may raise
+        NotImplementedError to have them simulated (inefficiently) by
+        the higher-level machinery of this class.
+
+        The possible values of whence and their meaning are defined
+        in the Linux man pages for `lseek()`:
+        http://man7.org/linux/man-pages/man2/lseek.2.html
+
+        SEEK_SET
+            The internal position pointer is set to offset bytes.
+        SEEK_CUR
+            The ipp is set to its current position plus offset bytes.
+        SEEK_END
+            The ipp is set to the size of the file plus offset bytes.
+        """
+        if whence == SEEK_SET:
+            self._ipp = offset
+            return
+
+        if whence == SEEK_CUR:
+            self._ipp += offset
+            return
+
+        if whence == SEEK_END:
+            self._ipp = self._size + offset
+            return
+
+        raise NotImplementedError(whence)
+
+    def _tell(self):
+        """Get the location of the file's internal position pointer.
+
+        This method must be implemented by subclasses that wish to be
+        seekable, and must return the position of the file's internal
+        pointer.
+
+        Due to buffering, the position seen by users of this class
+        (the "apparent position") may be different to the position
+        returned by this method (the "actual position").
+        """
+        return self._ipp
+
+    def _truncate(self, size):
+        """Truncate the file's size to <size>.
+
+        This method must be implemented by subclasses that wish to be
+        truncatable.  It must truncate the file to exactly the given size
+        or fail with an IOError.
+
+        Note that <size> will never be None; if it was not specified by the
+        user then it is calculated as the file's apparent position (which may
+        be different to its actual position due to buffering).
+        """
+        statmsg = self._file.truncate(size)[0]
+        if not statmsg.ok or statmsg.error:
+            raise IOError((statmsg.message, self))
+        else:
+            self._seek(size, SEEK_SET)
+            self._size = size
+
+    def _get_size(self):
+        """Get current size of file as reported by the XRootD server it is
+        on."""
+        return self._size
+
+    def _is_open(self):
+        """Checks if the wrapped XRootD-File object is open."""
+        return self._file.is_open()
+
+    def close(self):
+        """Flush write buffers and close the file.
+
+        The file may not be accessed further once it is closed.
+        """
+        if not self.closed:
+            super(XRootDFile, self).close()
+            if self._file.is_open():
+                self._file.close()


### PR DESCRIPTION
One huge commit. Used to be upwards of 100, but then they all got squashed together.

* Initial implementation of XRootDFile. It's basically just a translation layer between the PyFS interface and the XRootD-python interface.
  * `_write()`, `_read()`, `_seek()`, `_tell()`, `_truncate()` and `close()` implemented.
  * Also `_is_open()`, `_get_size()` as internal helper methods.
* Whole bunch of tests.
