### PR TITLE
xrdfile: pyxrootd call patterns and read() errors

### DIFF
--- a/tests/test_xrdfile.py
+++ b/tests/test_xrdfile.py
@@ -404,3 +404,11 @@ def test_init_streammodes(tmppath):
     xfile.close()
     xfile = XRootDFile(mkurl(fp), 'r')
     assert xfile.read() == conts
+
+
+def test_read_errors(tmppath):
+    fd = get_tsta_file(tmppath)
+    fp, fc = fd['full_path'], fd['contents']
+    xfile = XRootDFile(mkurl(fp), 'r')
+    xfile.close()
+    pytest.raises(ValueError, xfile.read)

--- a/xrootdfs/xrdfile.py
+++ b/xrootdfs/xrdfile.py
@@ -105,6 +105,9 @@ class XRootDFile(object):
         until None has been read from _read().  Once EOF is reached, it
         should be safe to call _read() again, immediately returning None.
         """
+        if self.closed:
+            raise ValueError("I/O operation on closed file.")
+
         self._assert_mode("r-")
 
         chunksize = sizehint if sizehint > 0 else self.size
@@ -115,6 +118,10 @@ class XRootDFile(object):
             size=chunksize,
             timeout=self.timeout,
         )
+
+        if not statmsg.ok or statmsg.error:
+            raise IOError("XRootD error reading file: {0}".format(
+                          statmsg.message))
 
         # Increment internal file pointer.
         self._ipp = min(self._ipp + chunksize, self.size)


### PR DESCRIPTION
Closes #7 and #8.