### PR TITLE
fs: move, movedir and rename implementation

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -35,7 +35,7 @@ where, ``<tmpfolder>`` is dependent on your system (e.g. on OS X it is
 ``/var/folders``, while on Linux it can be left empty).
 
 .. note::
-   XRootD have issues with Docker's default hostname, thus it's import to
+   XRootD have issues with Docker's default hostname, thus it is important to
    supply a host name to ``docker run`` via the ``-h`` option.
 
 Installing an XRootD server
@@ -57,8 +57,8 @@ RedHat based distributions/versions.
 Ubuntu
 ~~~~~~
 
-Unfortunately there is no official support for XRootD on Ubuntu. You will have
-to install XRootD from the source distribution.
+There is no official support for XRootD on Ubuntu, so you will have to install
+XRootD from the source distribution.
 
 OS X
 ~~~~

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,7 @@ USER xrootdfs
 
 RUN mkdir /tmp/xrootdfs && touch /tmp/xrootdfs/test.txt
 
+# Print xrootd version
+RUN xrootd -v
+
 CMD ["bash", "/code/run-docker.sh"]

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -16,7 +16,8 @@ from os.path import exists, join
 import pytest
 from fixture import mkurl, tmppath
 from fs.errors import BackReferenceError, DestinationExistsError, \
-    DirectoryNotEmptyError, InvalidPathError, ResourceInvalidError
+    DirectoryNotEmptyError, InvalidPathError, ResourceInvalidError, \
+    ResourceNotFoundError
 from xrootdfs import XRootDFile, XRootDFS
 from xrootdfs.utils import spliturl
 
@@ -99,7 +100,7 @@ def test_isfile(tmppath):
     rooturl = mkurl(tmppath)
     assert XRootDFS(rooturl).isfile("data/testa.txt")
     assert not XRootDFS(rooturl).isfile("data")
-    pytest.raises(InvalidPathError, XRootDFS(rooturl).isfile, "nofile")
+    pytest.raises(ResourceNotFoundError, XRootDFS(rooturl).isfile, "nofile")
 
 
 def test_isdir(tmppath):
@@ -107,7 +108,7 @@ def test_isdir(tmppath):
     rooturl = mkurl(tmppath)
     assert not XRootDFS(rooturl).isdir("data/testa.txt")
     assert XRootDFS(rooturl).isdir("data")
-    pytest.raises(InvalidPathError, XRootDFS(rooturl).isdir, "nofile")
+    pytest.raises(ResourceNotFoundError, XRootDFS(rooturl).isdir, "nofile")
 
 
 def test_exists(tmppath):
@@ -137,7 +138,7 @@ def test_makedir(tmppath):
     assert XRootDFS(rooturl).makedir("data", allow_recreate=True)
 
     # if a containing directory is missing and recursive is False
-    assert pytest.raises(ResourceInvalidError,
+    assert pytest.raises(ResourceNotFoundError,
                          XRootDFS(rooturl).makedir, "aa/bb/cc")
 
     # Recursive
@@ -159,7 +160,7 @@ def test_remove(tmppath):
     assert not XRootDFS(rooturl).exists("data/testa.txt")
 
     # Does not exists
-    assert pytest.raises(ResourceInvalidError, XRootDFS(rooturl).remove,
+    assert pytest.raises(ResourceNotFoundError, XRootDFS(rooturl).remove,
                          "a/testa.txt")
 
     # Directory not empty
@@ -175,16 +176,206 @@ def test_open(tmppath):
     """Test fs.open()"""
     # Create a file to open.
     file_name = 'data/testa.txt'
-    contents = 'testa.txt'
+    contents = 'testa.txt\n'
     xrd_rooturl = mkurl(tmppath)
-
-    full_file_path = '/' + join(tmppath, file_name)
 
     # Open file w/ xrootd
     xrdfs = XRootDFS(xrd_rooturl)
     xfile = xrdfs.open(file_name, mode='r')
     assert xfile
     assert type(xfile) == XRootDFile
+    assert xfile.read() == contents
+    xfile.close()
 
-    # cleanup
-    os.remove(full_file_path)
+
+def _get_content(fs, path):
+    f = fs.open(path, 'r')
+    content = f.read()
+    f.close()
+    return content
+
+
+def test_rename(tmppath):
+    """Test rename."""
+    fs = XRootDFS(mkurl(tmppath))
+
+    pytest.raises(
+        DestinationExistsError, fs.rename, "data/testa.txt", "multiline.txt")
+    pytest.raises(
+        DestinationExistsError, fs.rename, "data/testa.txt",
+        "afolder/afile.txt")
+    pytest.raises(
+        DestinationExistsError, fs.rename, "data/afolder", "bfolder")
+    pytest.raises(
+        DestinationExistsError, fs.rename, "data/afolder", "bfolder/bfile.txt")
+
+    assert fs.exists("data/testa.txt") and not fs.exists("data/testb.txt")
+    fs.rename("data/testa.txt", "testb.txt")
+    assert fs.exists("data/testb.txt") and not fs.exists("data/testa.txt")
+
+    assert fs.exists("data/afolder/") and not fs.exists("data/cfolder/")
+    fs.rename("data/afolder/", "cfolder")
+    assert fs.exists("data/cfolder") and not fs.exists("data/afolder")
+
+    fs.rename("data/cfolder/", "a/b/c/test")
+    assert fs.exists("data/a/b/c/test/")
+
+
+def test_move_good(tmppath):
+    """Test move file."""
+    fs = XRootDFS(mkurl(tmppath))
+
+    src_exists = "data/testa.txt"
+    dst_exists = "data/multiline.txt"
+    dst_new = "data/ok.txt"
+    dst_folder_exists = "data/bfolder/"
+    dst_folder_new = "data/anothernewfolder/"
+    content = _get_content(fs, src_exists)
+
+    assert fs.exists(dst_exists)
+    assert not fs.exists(dst_new)
+    assert fs.exists(dst_folder_exists)
+    assert not fs.exists(dst_folder_new)
+
+    fs.move(src_exists, dst_new)
+    assert not fs.exists(src_exists) and fs.exists(dst_new)
+
+    fs.move(dst_new, src_exists)
+    fs.move(src_exists, dst_folder_new)
+    assert not fs.exists(src_exists) and fs.exists(dst_folder_new)
+
+    fs.move(dst_folder_new, src_exists)
+    fs.move(src_exists, dst_exists, overwrite=True)
+    assert not fs.exists(src_exists) and fs.exists(dst_exists)
+    assert content == _get_content(fs, dst_exists)
+
+    fs.move(dst_exists, src_exists)
+    fs.move(src_exists, dst_folder_exists, overwrite=True)
+    assert not fs.exists(src_exists) and fs.exists(dst_folder_exists)
+    assert content == _get_content(fs, dst_folder_exists)
+
+
+def test_movedir_good(tmppath):
+    """Test move file."""
+    fs = XRootDFS(mkurl(tmppath))
+
+    src_exists = "data/afolder/"
+    dst_exists = "data/multiline.txt"
+    dst_new = "data/ok.txt"
+    dst_folder_exists = "data/bfolder/"
+    dst_folder_new = "data/anothernewfolder/"
+
+    assert fs.isdir(src_exists)
+    assert fs.exists(dst_exists)
+    assert not fs.exists(dst_new)
+    assert fs.exists(dst_folder_exists)
+    assert not fs.exists(dst_folder_new)
+
+    fs.movedir(src_exists, dst_new)
+    assert not fs.exists(src_exists) and fs.exists(dst_new)
+
+    fs.movedir(dst_new, src_exists)
+    fs.movedir(src_exists, dst_folder_new)
+    assert not fs.exists(src_exists) and fs.exists(dst_folder_new)
+
+    fs.movedir(dst_folder_new, src_exists)
+    fs.movedir(src_exists, dst_exists, overwrite=True)
+    assert not fs.exists(src_exists) and fs.exists(dst_exists)
+    assert fs.isdir(dst_exists)
+
+    fs.movedir(dst_exists, src_exists)
+    fs.movedir(src_exists, dst_folder_exists, overwrite=True)
+    assert not fs.exists(src_exists) and fs.exists(dst_folder_exists)
+    assert fs.isdir(dst_folder_exists)
+
+
+def test_move_bad(tmppath):
+    """Test move file."""
+    fs = XRootDFS(mkurl(tmppath))
+
+    src_exists = "data/testa.txt"
+    src_new = "data/testb.txt"
+    src_folder_exists = "data/afolder/"
+    src_folder_new = "data/newfolder/"
+    dst_exists = "data/multiline.txt"
+    dst_new = "data/ok.txt"
+    dst_folder_exists = "data/bfolder/"
+    dst_folder_new = "data/anothernewfolder/"
+
+    # Destination exists
+    pytest.raises(
+        DestinationExistsError, fs.move, src_exists, dst_exists)
+    pytest.raises(
+        DestinationExistsError, fs.move, src_exists, src_exists)
+    pytest.raises(
+        DestinationExistsError, fs.move, src_exists, dst_folder_exists)
+
+    # Cannot move dir
+    pytest.raises(
+        ResourceInvalidError, fs.move, src_folder_exists, dst_new)
+    pytest.raises(
+        ResourceInvalidError, fs.move, src_folder_exists, dst_folder_new)
+
+    # Source doesn't exists
+    pytest.raises(ResourceNotFoundError, fs.move, src_new, dst_exists)
+    pytest.raises(ResourceNotFoundError, fs.move, src_new, dst_new)
+    pytest.raises(ResourceNotFoundError, fs.move, src_new, dst_folder_exists)
+    pytest.raises(ResourceNotFoundError, fs.move, src_new, dst_folder_new)
+
+    pytest.raises(
+        ResourceNotFoundError, fs.move, src_folder_new, dst_exists)
+    pytest.raises(
+        ResourceNotFoundError, fs.move, src_folder_new, dst_new)
+    pytest.raises(
+        ResourceNotFoundError, fs.move, src_folder_new, dst_folder_exists)
+    pytest.raises(
+        ResourceNotFoundError, fs.move, src_folder_new, dst_folder_new)
+
+
+def test_movedir_bad(tmppath):
+    """Test move file."""
+    fs = XRootDFS(mkurl(tmppath))
+
+    src_exists = "data/testa.txt"
+    src_new = "data/testb.txt"
+    src_folder_exists = "data/afolder/"
+    src_folder_new = "data/newfolder/"
+    dst_exists = "data/multiline.txt"
+    dst_new = "data/ok.txt"
+    dst_folder_exists = "data/bfolder/"
+    dst_folder_new = "data/anothernewfolder/"
+
+    # Destination exists
+    pytest.raises(
+        DestinationExistsError, fs.movedir, src_folder_exists, dst_exists)
+    pytest.raises(
+        DestinationExistsError, fs.movedir, src_folder_exists,
+        src_folder_exists)
+    pytest.raises(
+        DestinationExistsError, fs.movedir, src_folder_exists,
+        dst_folder_exists)
+
+    # Cannot move file
+    pytest.raises(
+        ResourceInvalidError, fs.movedir, src_exists, dst_new)
+    pytest.raises(
+        ResourceInvalidError, fs.movedir, src_exists, dst_folder_new)
+
+    # Source doesn't exists
+    pytest.raises(
+        ResourceNotFoundError, fs.movedir, src_new, dst_exists)
+    pytest.raises(
+        ResourceNotFoundError, fs.movedir, src_new, dst_new)
+    pytest.raises(
+        ResourceNotFoundError, fs.movedir, src_new, dst_folder_exists)
+    pytest.raises(
+        ResourceNotFoundError, fs.movedir, src_new, dst_folder_new)
+
+    pytest.raises(
+        ResourceNotFoundError, fs.movedir, src_folder_new, dst_exists)
+    pytest.raises(
+        ResourceNotFoundError, fs.movedir, src_folder_new, dst_new)
+    pytest.raises(
+        ResourceNotFoundError, fs.movedir, src_folder_new, dst_folder_exists)
+    pytest.raises(
+        ResourceNotFoundError, fs.movedir, src_folder_new, dst_folder_new)

--- a/xrootdfs/__init__.py
+++ b/xrootdfs/__init__.py
@@ -36,7 +36,7 @@ The XRootDFS package is on PyPI so all you need is:
 
 .. code-block:: console
 
-    $ pip install XRootDFS
+    $ pip install xrootdfs
 
 XRootDFS depends on `PyFilesystem <http://docs.pyfilesystem.org>`_ and
 `XRootD Python bindings <http://xrootd.org/doc/python/xrootd-python-0.1.0/>`_.
@@ -78,9 +78,6 @@ Or, alternatively using the PyFilesystem opener:
     >>> fs, path = opener.parse("root://localhost//tmp/")
     >>> fs.listdir("xrootdfs")
     [u'test.txt']
-
-Usage
-=====
 """
 
 from __future__ import absolute_import, print_function, unicode_literals


### PR DESCRIPTION
* Adds support for move, movedir and rename methods. (addresses #9)

* Fixes bug in XRootDFS._stat_info which did not access the right
  attribute.

* Fixes issue with removedir not being able to remove a non-empty
  directory.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>