### PR TITLE
xrdfile: incr. test cov, address seek() issues

### DIFF
--- a/tests/test_xrdfile.py
+++ b/tests/test_xrdfile.py
@@ -15,7 +15,8 @@ from os.path import join
 import fs.path
 import pytest
 from fs import SEEK_CUR, SEEK_END, SEEK_SET
-from fs.errors import InvalidPathError, PathError, ResourceNotFoundError
+from fs.errors import InvalidPathError, PathError, ResourceNotFoundError, \
+    UnsupportedError
 from fs.opener import fsopendir, opener
 
 from fixture import mkurl, tmppath
@@ -617,6 +618,34 @@ def test_init_streammodes(tmppath):
     xfile.close()
     xfile = XRootDFile(mkurl(fp), 'r')
     assert xfile.read() == conts
+
+
+def test_init_newline(tmppath):
+    """Tests fs.open() with specified newline parameter."""
+    fd = get_tsta_file(tmppath)
+    fp, fc = fd['full_path'], fd['contents']
+
+    xfile = XRootDFile(mkurl(fp))
+    assert xfile._newline is None
+    xfile.close()
+
+    xfile = XRootDFile(mkurl(fp), newline='\n')
+    assert xfile._newline == '\n'
+    xfile.close()
+
+    pytest.raises(UnsupportedError, XRootDFile, mkurl(fp), mode='r',
+                  newline='what')
+
+
+def test_init_notimplemented(tmppath):
+    """Tests that specifying not-implemented args to XRDFile's constructor
+       results in an error."""
+    fd = get_tsta_file(tmppath)
+    fp, fc = fd['full_path'], fd['contents']
+
+    pytest.raises(NotImplementedError, XRootDFile, mkurl(fp), buffering='')
+    pytest.raises(NotImplementedError, XRootDFile, mkurl(fp),
+                  line_buffering='')
 
 
 def test_read_errors(tmppath):

--- a/xrootdfs/fs.py
+++ b/xrootdfs/fs.py
@@ -150,6 +150,8 @@ class XRootDFS(FS):
         :raises `fs.errors.ResourceInvalidError`: if an intermediate directory
             is an file
         :raises `fs.errors.ResourceNotFoundError`: if the path is not found
+
+        : raises some error if newline is anything else than 'slash n' or None
         """
         # Set default timeout if not overwritten.
         kwargs.setdefault("timeout", self.timeout)

--- a/xrootdfs/xrdfile.py
+++ b/xrootdfs/xrdfile.py
@@ -150,8 +150,10 @@ class XRootDFile(object):
         not 0, an empty string is returned only when EOF is encountered
         immediately.
         """
+        chunksize = sizehint if sizehint is not None else 0
+
         self._assert_mode("r-")
-        return self._file.readline(chunksize=sizehint)
+        return self._file.readline(chunksize=chunksize)
 
     def readlines(self, sizehint=None):
         """Read until EOF using readline().
@@ -209,6 +211,13 @@ class XRootDFile(object):
         """
         if "-" in self.mode:
             raise IOError("File is not seekable.")
+
+        # Convert to integer by rounding down/omitting everything after
+        # the decimal point
+        offset = int(offset)
+
+        if offset < 0:
+            raise IOError("Invalid argument.")
 
         if whence == SEEK_SET:
             self._ipp = offset

--- a/xrootdfs/xrdfile.py
+++ b/xrootdfs/xrdfile.py
@@ -11,7 +11,8 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 from fs import SEEK_CUR, SEEK_END, SEEK_SET
-from fs.errors import InvalidPathError, PathError, ResourceNotFoundError
+from fs.errors import InvalidPathError, PathError, ResourceNotFoundError, \
+    UnsupportedError
 from XRootD.client import File
 
 from .utils import is_valid_path, is_valid_url, spliturl, \
@@ -55,6 +56,15 @@ class XRootDFile(object):
         if not is_valid_path(xpath):
             raise InvalidPathError(xpath)
 
+        if newline is not None and not newline == '\n':
+            raise UnsupportedError("Newline character not supported, "
+                                   "must be None or '\\n'.")
+        if buffering is not -1:
+            raise NotImplementedError("Specifying buffering not implemented.")
+        if line_buffering is not False:
+            raise NotImplementedError("Specifying line buffering not "
+                                      "implemented.")
+
         # PyFS attributes
         self.mode = mode
 
@@ -64,6 +74,11 @@ class XRootDFile(object):
         self._ipp = 0
         self._size = -1
         self._iterator = None
+        self._buffering = buffering
+        self._encoding = encoding
+        self._errors = errors
+        self._newline = newline
+        self._line_buffering = line_buffering
         self.timeout = timeout
 
         # flag translation


### PR DESCRIPTION
Rebased #50 into this.

* Adds `_newline`, `_buffering`, `_line_buffering`, `_encoding`, `_errors`
  properties to XRootDFile

* Raises an UnsupportedError if anything else than None or '\n' is
  passed as newline to XRootDFile's constructor.
  (addresses #4)

* Raises NotImplementedError if buffering or line_buffering is specified
  as non-default during initialization of an XRootDFile.
  (addresses #4)

* Adds tests to increase test coverage for glorious benefit of
  public senator project.
  (addresses #5)

* Adds tests for readline()
  (addresses #5)

* Sets chunksize to 0 if sizehint is None
  (closes #33)

* Adds tests for seek() using non-default values for `whence`.
  (addresses #34)

* seek() raises IOError when offset < 0
  (closes #48)

* seek() converts offset arg to int via int()
  (closes #49)

Signed-off-by: Odd Magnus Trondrud <odd.magnus.trondrud@cern.ch>