### PR TITLE
tests: pytest 2.8.0 and coverage 4.0 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN adduser --uid 1001 xrootdfs
 RUN pip install --upgrade pip setuptools
 RUN pip install ipython \
                 pep257 \
-                "pytest<2.8.0" \
+                coverage \
+                pytest \
                 pytest-pep8 \
                 pytest-cache \
                 pytest-cov \
@@ -36,7 +37,7 @@ RUN pip install fs
 
 # Add sources to `code` and work there:
 WORKDIR /code
-ADD . /code
+COPY . /code
 
 RUN pip install -e .
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,4 @@
 # terms of the Revised BSD License; see LICENSE file for more details.
 
 [pytest]
-addopts = --clearcache --pep8 --isort --ignore=docs --cov=xrootdfs --cov-report=term-missing tests xrootdfs
+addopts = --pep8 --isort --ignore=docs --cov=xrootdfs --cov-report=term-missing tests xrootdfs

--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,6 @@ class PyTest(TestCommand):
         """Run tests."""
         # import here, cause outside the eggs aren't loaded
         import pytest
-        import _pytest.config
-        pm = _pytest.config.get_plugin_manager()
-        pm.consider_setuptools_entrypoints()
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 
@@ -57,13 +54,13 @@ with open(os.path.join('xrootdfs', 'version.py'), 'rt') as f:
     ).group('version')
 
 tests_require = [
-    'pytest-cache>=1.0',
-    'pytest-cov>=1.8.0',
-    'pytest-pep8>=1.0.6',
-    'pytest-isort>=0.1.0',
-    'pytest>=2.6.1,<2.8.0',
-    'coverage<4.0a1',
+    'coverage>=4.0',
     'mock>=1.3.0',
+    'pytest-cache>=1.0',
+    'pytest-cov>=2.0.0',
+    'pytest-isort>=0.1.0',
+    'pytest-pep8>=1.0.6',
+    'pytest>=2.8.0',
 ]
 
 setup(


### PR DESCRIPTION
* Adds support for pytest 2.8.0 and coverage 4.0.

* Changes Dockerfile to copy sources in order to ignore e.g. pyc
  and __pycache__ files.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>