### PR TITLE
Increase test coverage for xrdfile to >90%, minor fixes

### DIFF
--- a/tests/test_xrdfile.py
+++ b/tests/test_xrdfile.py
@@ -914,3 +914,31 @@ def test_flush(tmppath):
     # (which is called by flush())
     xfile._file.sync = Mock(return_value=(XRootDStatus(fake_status), None))
     pytest.raises(IOError, xfile.flush)
+
+
+def test__assert_mode(tmppath):
+    """Tests for _assert_mode"""
+    fd = get_tsta_file(tmppath)
+    full_path, fc = fd['full_path'], fd['contents']
+    mode = 'r'
+    xfile = XRootDFile(mkurl(full_path), mode)
+
+    assert xfile.mode == mode
+    assert xfile._assert_mode(mode)
+    delattr(xfile, 'mode')
+    pytest.raises(AttributeError, xfile._assert_mode, mode)
+
+    xfile.close()
+    xfile = XRootDFile(mkurl(full_path), 'r')
+    assert xfile._assert_mode('r')
+    pytest.raises(IOError, xfile._assert_mode, 'w')
+
+    xfile.close()
+    xfile = XRootDFile(mkurl(full_path), 'w-')
+    assert xfile._assert_mode('w-')
+    pytest.raises(IOError, xfile._assert_mode, 'r')
+
+    xfile.close()
+    xfile = XRootDFile(mkurl(full_path), 'a')
+    assert xfile._assert_mode('w')
+    pytest.raises(IOError, xfile._assert_mode, 'r')

--- a/xrootdfs/xrdfile.py
+++ b/xrootdfs/xrdfile.py
@@ -274,7 +274,7 @@ class XRootDFile(object):
     def flush(self):
         """Flush write buffers."""
         if not self.closed:
-            statmsg = self._file.sync()
+            statmsg, res = self._file.sync()
             if not statmsg.ok or statmsg.error:
                 raise IOError("XRootD error while flushing write buffer: {0}".
                               format(statmsg.message))

--- a/xrootdfs/xrdfile.py
+++ b/xrootdfs/xrdfile.py
@@ -301,7 +301,9 @@ class XRootDFile(object):
             try:
                 mstr = self.mode
             except AttributeError:
-                mstr = "r+"
+                raise AttributeError("Mode attribute missing -- "
+                                     "was it deleted? "
+                                     "Close and re-open the file.")
         if "+" in mstr:
             return True
         if "-" in mstr and "-" not in mode:

--- a/xrootdfs/xrdfile.py
+++ b/xrootdfs/xrdfile.py
@@ -82,7 +82,7 @@ class XRootDFile(object):
         self._flags = translate_file_mode_to_flags(mode)
 
         statmsg, response = self._file.open(path, flags=self._flags)
-        if not statmsg.ok or statmsg.error:
+        if not statmsg.ok:
             if statmsg.errno == 3011:
                 raise ResourceNotFoundError(path)
             else:
@@ -138,7 +138,7 @@ class XRootDFile(object):
             size=chunksize,
         )
 
-        if not statmsg.ok or statmsg.error:
+        if not statmsg.ok:
             raise IOError("XRootD error reading file: {0}".format(
                           statmsg.message))
 
@@ -195,7 +195,7 @@ class XRootDFile(object):
 
         statmsg, res = self._file.write(string, offset=self._ipp)
 
-        if not statmsg.ok or statmsg.error:
+        if not statmsg.ok:
             raise IOError("XRootD error writing to file: {0}".format(
                           statmsg.message))
 
@@ -254,7 +254,7 @@ class XRootDFile(object):
             size = self.tell()
 
         statmsg = self._file.truncate(size)[0]
-        if not statmsg.ok or statmsg.error:
+        if not statmsg.ok:
             raise IOError("XRootD error while truncating: {0}".format(
                           statmsg.message))
 
@@ -272,7 +272,7 @@ class XRootDFile(object):
         """Flush write buffers."""
         if not self.closed:
             statmsg, res = self._file.sync()
-            if not statmsg.ok or statmsg.error:
+            if not statmsg.ok:
                 raise IOError("XRootD error while flushing write buffer: {0}".
                               format(statmsg.message))
 
@@ -286,7 +286,7 @@ class XRootDFile(object):
         """Get file size."""
         if self._size == -1:
             statmsg, res = self._file.stat()
-            if not statmsg.ok or statmsg.error:
+            if not statmsg.ok:
                 raise IOError("XRootD error while retrieving size: {0}".format(
                               statmsg.message))
             self._size = res.size

--- a/xrootdfs/xrdfile.py
+++ b/xrootdfs/xrdfile.py
@@ -250,9 +250,6 @@ class XRootDFile(object):
         """
         self._assert_mode('w')
 
-        if "-" in self.mode:
-            raise IOError("File is not seekable; can't truncate.")
-
         if size is None:
             size = self.tell()
 

--- a/xrootdfs/xrdfile.py
+++ b/xrootdfs/xrdfile.py
@@ -41,8 +41,7 @@ class XRootDFile(object):
     """
 
     def __init__(self, path, mode='r', buffering=-1, encoding=None,
-                 errors=None, newline=None, line_buffering=False, timeout=0,
-                 **kwargs):
+                 errors=None, newline=None, line_buffering=False, **kwargs):
         """XRootDFile constructor.
 
         Raises PathError if the given path isn't a valid XRootD URL,
@@ -64,7 +63,6 @@ class XRootDFile(object):
         if line_buffering is not False:
             raise NotImplementedError("Specifying line buffering not "
                                       "implemented.")
-
         # PyFS attributes
         self.mode = mode
 
@@ -79,13 +77,11 @@ class XRootDFile(object):
         self._errors = errors
         self._newline = newline
         self._line_buffering = line_buffering
-        self.timeout = timeout
 
         # flag translation
         self._flags = translate_file_mode_to_flags(mode)
 
-        statmsg, response = self._file.open(path, flags=self._flags,
-                                            timeout=self.timeout)
+        statmsg, response = self._file.open(path, flags=self._flags)
         if not statmsg.ok or statmsg.error:
             if statmsg.errno == 3011:
                 raise ResourceNotFoundError(path)
@@ -140,7 +136,6 @@ class XRootDFile(object):
         statmsg, res = self._file.read(
             offset=self._ipp,
             size=chunksize,
-            timeout=self.timeout,
         )
 
         if not statmsg.ok or statmsg.error:
@@ -198,8 +193,7 @@ class XRootDFile(object):
         if 'a' in self.mode:
             self.seek(0, SEEK_END)
 
-        statmsg, res = self._file.write(string, offset=self._ipp,
-                                        timeout=self.timeout)
+        statmsg, res = self._file.write(string, offset=self._ipp)
 
         if not statmsg.ok or statmsg.error:
             raise IOError("XRootD error writing to file: {0}".format(
@@ -262,7 +256,7 @@ class XRootDFile(object):
         if size is None:
             size = self.tell()
 
-        statmsg = self._file.truncate(size, timeout=self.timeout)[0]
+        statmsg = self._file.truncate(size)[0]
         if not statmsg.ok or statmsg.error:
             raise IOError("XRootD error while truncating: {0}".format(
                           statmsg.message))
@@ -275,12 +269,12 @@ class XRootDFile(object):
         The file may not be accessed further once it is closed.
         """
         if not self.closed:
-            self._file.close(timeout=self.timeout)
+            self._file.close()
 
     def flush(self):
         """Flush write buffers."""
         if not self.closed:
-            statmsg = self._file.sync(timeout=self.timeout)
+            statmsg = self._file.sync()
             if not statmsg.ok or statmsg.error:
                 raise IOError("XRootD error while flushing write buffer: {0}".
                               format(statmsg.message))
@@ -294,7 +288,7 @@ class XRootDFile(object):
     def size(self):
         """Get file size."""
         if self._size == -1:
-            statmsg, res = self._file.stat(timeout=self.timeout)
+            statmsg, res = self._file.stat()
             if not statmsg.ok or statmsg.error:
                 raise IOError("XRootD error while retrieving size: {0}".format(
                               statmsg.message))


### PR DESCRIPTION
* removes references to timeout
* bumps the test coverage up for supported/implemented functions (i.e. no readline etc)
  * Can't get to >98% (ref. #5) without functional implementations of readline(), readlines(), next()/iterator and xreadlines(). Or, we could, but if we're not implementing them we should just remove them rather than ship with tested but broken implementations.
* tests for _assert_mode
* mocks xrootd status response objects for some functions to get that test coverage up.
